### PR TITLE
Increase RSA key size to 4096 bits to support larger configuration

### DIFF
--- a/web/scripts/generate-keys.ts
+++ b/web/scripts/generate-keys.ts
@@ -10,7 +10,7 @@ if (!fs.existsSync(KEYS_DIR)) {
 
 function generateKeyPair() {
   return crypto.generateKeyPairSync('rsa', {
-    modulusLength: 2048,
+    modulusLength: 4096,
     publicKeyEncoding: {
       type: 'spki',
       format: 'pem',


### PR DESCRIPTION
**Features**

- Increased RSA key size from 2048 bits to 4096 bits to support encrypting larger config blobs
- Prevented `ERR_OSSL_RSA_DATA_TOO_LARGE_FOR_MODULUS` errors during user signup and config saving flows

**Feature Docs**

- No major new features or docs changes required.  
- Follows existing `generate-keys.ts` process with a single line adjustment (`modulusLength: 4096`).

**Influence**

- Enables support for larger configurations without encryption/decryption failures.
- Google AI API keys, for example, could not fit in that modulus size.
- Maintains compatibility with all existing frontend and backend code (no interface or API changes).
- No database schema updates or migration needed.

**Result**

- ✅ User signup no longer fails due to RSA decryption errors
- ✅ Large configuration blobs (with larger API keys) are now handled without issues
- ✅ Local testing and Docker container startup verified without cryptographic errors

**Other**

- This is a minor but critical stability improvement.
- No changes to authentication or token generation flows.
- Existing deployments should regenerate new keys manually after updating.
